### PR TITLE
gsd/develop: add capability to call radiation on physics timestep for first N time steps

### DIFF
--- a/physics/GFS_time_vary_pre.fv3.F90
+++ b/physics/GFS_time_vary_pre.fv3.F90
@@ -65,9 +65,9 @@
 !> \section arg_table_GFS_time_vary_pre_run Argument Table
 !! \htmlinclude GFS_time_vary_pre_run.html
 !!
-      subroutine GFS_time_vary_pre_run (jdat, idat, dtp, lsm, lsm_noahmp, nsswr, &
-        nslwr, idate, debug, me, master, nscyc, sec, phour, zhour, fhour, kdt,   &
-        julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg, errflg)
+      subroutine GFS_time_vary_pre_run (jdat, idat, dtp, lsm, lsm_noahmp, nsswr,  &
+        nslwr, nhfrad, idate, debug, me, master, nscyc, sec, phour, zhour, fhour, &
+        kdt, julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg, errflg)
 
         use machine,               only: kind_phys
 
@@ -77,7 +77,7 @@
         integer,                          intent(in)    :: jdat(1:8), idat(1:8)
         integer,                          intent(in)    :: lsm, lsm_noahmp,      &
                                                            nsswr, nslwr, me,     &
-                                                           master, nscyc
+                                                           master, nscyc, nhfrad
         logical,                          intent(in)    :: debug
         real(kind=kind_phys),             intent(in)    :: dtp
 
@@ -169,6 +169,12 @@
         !--- allow for radiation to be called on every physics time step, if needed
         if (nsswr == 1)  lsswr = .true.
         if (nslwr == 1)  lslwr = .true.
+        !--- allow for radiation to be called on every physics time step
+        !    for the first nhfrad timesteps (for spinup, coldstarts only)
+        if (kdt<=nhfrad) then
+           lsswr = .true.
+           lslwr = .true.
+        end if
 
         !--- set the solar hour based on a combination of phour and time initial hour
         solhr  = mod(phour+idate(1),con_24)

--- a/physics/GFS_time_vary_pre.fv3.meta
+++ b/physics/GFS_time_vary_pre.fv3.meta
@@ -102,6 +102,14 @@
   type = integer
   intent = in
   optional = F
+[nhfrad]
+  standard_name = number_of_timesteps_for_radiation_calls_on_physics_timestep
+  long_name = number of timesteps for radiation calls on physics timestep (coldstarts only)
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [idate]
   standard_name = date_and_time_at_model_initialization_reordered
   long_name = initial date with different size and ordering


### PR DESCRIPTION
This PR adds the capability to allow for radiation being called on physics timestep for first nhfrad timesteps (coldstarts only, for spinup) to physics/GFS_time_vary_pre.fv3.*

The new functionality is activated by setting nhfrad in the gfs physics namelist section to a value larger than one (default is zero).

Associated PR: https://github.com/climbfuji/fv3atm/pull/1

This PR has been tested to work on macOS/GNU and needs to be tested for b4b identical results when nhfrad is not set (default value is zero) on hera/intel. 