### PR TITLE
Changes necessary to remove GSD_SURFACE_FLUXES_BUGFIX from ccpp-physics

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -373,7 +373,7 @@ contains
 !! \htmlinclude GFS_surface_composites_post_run.html
 !!
    subroutine GFS_surface_composites_post_run (                                                                                   &
-      im, kice, km, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, wind, t1, q1, prsl1,                         &
+      im, kice, km, cplflx, cplwav2atm, frac_grid, flag_cice, thsfc_loc, islmsk, dry, wet, icy, wind, t1, q1, prsl1,              &
       rd, rvrdm1, landfrac, lakefrac, oceanfrac, zorl, zorlo, zorll, zorli,                                                       &
       cd, cd_wat, cd_lnd, cd_ice, cdq, cdq_wat, cdq_lnd, cdq_ice, rb, rb_wat, rb_lnd, rb_ice, stress, stress_wat, stress_lnd,     &
       stress_ice, ffmm, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh, ffhh_wat, ffhh_lnd, ffhh_ice, uustar, uustar_wat, uustar_lnd,         &
@@ -410,6 +410,7 @@ contains
       real(kind=kind_phys), dimension(im, km),    intent(inout) :: stc
 
       ! Additional data needed for calling "stability"
+      logical,                            intent(in   ) :: thsfc_loc
       real(kind=kind_phys),               intent(in   ) :: grav
       real(kind=kind_phys), dimension(:), intent(in   ) :: prslki, z1, ztmax_wat, ztmax_lnd, ztmax_ice
 
@@ -420,7 +421,7 @@ contains
       integer :: i, k
       real(kind=kind_phys) :: txl, txi, txo, wfrac, q0, rho
       ! For calling "stability"
-      real(kind=kind_phys) :: tsurf, virtfac, thv1, tvs, z0max, ztmax
+      real(kind=kind_phys) :: tsurf, virtfac, tv1, thv1, tvs, z0max, ztmax
 
       ! Initialize CCPP error handling variables
       errmsg = ''
@@ -475,24 +476,27 @@ contains
 
           q0 = max( q1(i), qmin )
           virtfac = one + rvrdm1 * q0
-#ifdef GSD_SURFACE_FLUXES_BUGFIX
-          thv1 = t1(i) / prslk1(i) * virtfac  ! Theta-v at lowest level
-          tvs  = half * (tsfc(i)+tsurf)/prsik1(i) * virtfac
-#else
-          thv1 = t1(i) * prslki(i) * virtfac  ! Theta-v at lowest level
-          tvs  = half * (tsfc(i)+tsurf) * virtfac
-#endif
+          tv1 = t1(i) * virtfac
+
+          if(thsfc_loc) then ! Use local potential temperature
+            thv1 = t1(i) * prslki(i) * virtfac  ! Theta-v at lowest level
+            tvs  = half * (tsfc(i)+tsurf) * virtfac
+          else ! Use potential temperature referenced to 1000 hPa
+            thv1 = t1(i) / prslk1(i) * virtfac  ! Theta-v at lowest level
+            tvs  = half * (tsfc(i)+tsurf)/prsik1(i) * virtfac
+          endif
 
           zorl(i) = exp(txl*log(zorll(i)) + txi*log(zorli(i)) + txo*log(zorlo(i)))
           z0max   = 0.01_kind_phys * zorl(i)
           ztmax   = exp(txl*log(ztmax_lnd(i)) + txi*log(ztmax_ice(i)) + txo*log(ztmax_wat(i)))
 
           call stability(z1(i), snowd(i), thv1, wind(i), z0max, ztmax, tvs, grav, & ! inputs
+                         tv1, thsfc_loc,                                          & ! inputs
                          rb(i), ffmm(i), ffhh(i), fm10(i), fh2(i), cd(i), cdq(i), & ! outputs
                          stress(i), uustar(i))
 
           ! BWG, 2021/02/25: cmm=cd*wind, chh=cdq*wind, so use composite cd, cdq
-          rho      = prsl1(i) / (rd*t1(i)*(one + rvrdm1*q0))
+          rho      = prsl1(i) / (rd*t1(i)*virtfac)
           cmm(i)    =      cd(i)*wind(i)  !txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
           chh(i)    = rho*cdq(i)*wind(i)  !txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
 

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -476,8 +476,8 @@ contains
 
           q0 = max( q1(i), qmin )
           virtfac = one + rvrdm1 * q0
-          tv1 = t1(i) * virtfac
 
+          tv1 = t1(i) * virtfac ! Virtual temperature in middle of lowest layer
           if(thsfc_loc) then ! Use local potential temperature
             thv1 = t1(i) * prslki(i) * virtfac  ! Theta-v at lowest level
             tvs  = half * (tsfc(i)+tsurf) * virtfac

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -71,6 +71,14 @@
   type = logical
   intent = in
   optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [cplflx]
   standard_name = flag_for_flux_coupling
   long_name = flag controlling cplflx collection (default off)

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -71,14 +71,6 @@
   type = logical
   intent = in
   optional = F
-[thsfc_loc]
-  standard_name = flag_for_reference_pressure_theta
-  long_name = flag for reference pressure in theta calculation
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [cplflx]
   standard_name = flag_for_flux_coupling
   long_name = flag controlling cplflx collection (default off)
@@ -913,6 +905,14 @@
   long_name = flag for cice
   units = flag
   dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = in
+  optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
   type = logical
   intent = in
   optional = F

--- a/physics/sfc_diag.f
+++ b/physics/sfc_diag.f
@@ -23,7 +23,7 @@
 !!  @{
       subroutine sfc_diag_run                                           &
      &                   (im,grav,cp,eps,epsm1,ps,u1,v1,t1,q1,prslki,   &
-     &                    evap,fm,fh,fm10,fh2,tskin,qsurf,              &
+     &                    evap,fm,fh,fm10,fh2,tskin,qsurf,thsfc_loc,    &
      &                    f10m,u10m,v10m,t2m,q2m,errmsg,errflg          &
      &                   )
 !
@@ -32,6 +32,7 @@
       implicit none
 !
       integer, intent(in) :: im
+      logical, intent(in) :: thsfc_loc  ! Flag for reference pot. temp.
       real(kind=kind_phys), intent(in) :: grav,cp,eps,epsm1
       real(kind=kind_phys), dimension(im), intent(in) ::                &
      &                       ps, u1, v1, t1, q1, tskin,                 &
@@ -74,11 +75,12 @@
 !       t2m(i)  = t2m(i) * sig2k
         wrk     = 1.0 - fhi
 
-#ifdef GSD_SURFACE_FLUXES_BUGFIX
-        t2m(i)  = tskin(i)*wrk + t1(i)*fhi - (grav+grav)/cp
-#else
-        t2m(i)  = tskin(i)*wrk + t1(i)*prslki(i)*fhi - (grav+grav)/cp
-#endif
+
+        if(thsfc_loc) then ! Use local potential temperature
+          t2m(i)  = tskin(i)*wrk + t1(i)*prslki(i)*fhi - (grav+grav)/cp
+        else ! Use potential temperature referenced to 1000 hPa
+          t2m(i)  = tskin(i)*wrk + t1(i)*fhi - (grav+grav)/cp
+        endif
 
         if(evap(i) >= 0.) then !  for evaporation>0, use inferred qsurf to deduce q2m
           q2m(i) = qsurf(i)*wrk + max(qmin,q1(i))*fhi

--- a/physics/sfc_diag.meta
+++ b/physics/sfc_diag.meta
@@ -168,6 +168,14 @@
   kind = kind_phys
   intent = in
   optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [f10m]
   standard_name = ratio_of_wind_at_lowest_model_layer_and_wind_at_10m
   long_name = ratio of fm10 and fm

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -250,6 +250,14 @@
   type = logical
   intent = in
   optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [tskin_wat]
   standard_name = surface_skin_temperature_over_water_interstitial
   long_name = surface skin temperature over water (temporary use as interstitial)

--- a/physics/sfc_nst.f
+++ b/physics/sfc_nst.f
@@ -32,7 +32,7 @@
      &       sinlat, stress,                                            &
      &       sfcemis, dlwflx, sfcnsw, rain, timestep, kdt, solhr,xcosz, &
      &       wind, flag_iter, flag_guess, nstf_name1, nstf_name4,       &
-     &       nstf_name5, lprnt, ipr,                                    &
+     &       nstf_name5, lprnt, ipr, thsfc_loc,                         &
      &       tskin, tsurf, xt, xs, xu, xv, xz, zm, xtts, xzts, dt_cool, &  ! --- input/output:
      &       z_c,   c_0,   c_d,   w_0, w_d, d_conv, ifd, qrain,         &
      &       qsurf, gflux, cmm, chh, evap, hflx, ep, errmsg, errflg     &  ! --- outputs:
@@ -50,7 +50,7 @@
 !            prsl1, prslki, wet, use_flake, xlon, sinlat, stress,       !
 !            sfcemis, dlwflx, sfcnsw, rain, timestep, kdt,solhr,xcosz,  !
 !            wind,  flag_iter, flag_guess, nstf_name1, nstf_name4,      !
-!            nstf_name5, lprnt, ipr,                                    !
+!            nstf_name5, lprnt, ipr, thsfc_loc,                         !
 !       input/outputs:                                                  !
 !            tskin, tsurf, xt, xs, xu, xv, xz, zm, xtts, xzts, dt_cool, !
 !            z_c, c_0,   c_d,   w_0, w_d, d_conv, ifd, qrain,           !
@@ -123,6 +123,7 @@
 !                nstf_name5 : zsea2 in mm                          1    !
 !     lprnt    - logical, control flag for check print out         1    !
 !     ipr      - integer, grid index for check print out           1    !
+!     thsfc_loc- logical, flag for reference pressure in theta     1    !
 !                                                                       !
 !  input/outputs:
 ! li added for oceanic components
@@ -199,6 +200,7 @@
      &                                      use_flake 
 !    &,      icy
       logical,                intent(in) :: lprnt
+      logical,                intent(in) :: thsfc_loc
 
 !  ---  input/outputs:
 ! control variables of dtl system (5+2) and sl (2) and coefficients for d(tz)/d(ts) calculation
@@ -297,11 +299,13 @@ cc
           wndmag(i) = sqrt(u1(i)*u1(i) + v1(i)*v1(i))
 
           q0(i)     = max(q1(i), 1.0e-8_kp)
-#ifdef GSD_SURFACE_FLUXES_BUGFIX
-          theta1(i) = t1(i) / prslk1(i) ! potential temperature at the middle of lowest model layer
-#else
-          theta1(i) = t1(i) * prslki(i)
-#endif
+
+          if(thsfc_loc) then ! Use local potential temperature
+            theta1(i) = t1(i) * prslki(i)
+          else ! Use potential temperature referenced to 1000 hPa
+            theta1(i) = t1(i) / prslk1(i) ! potential temperature at the middle of lowest model layer
+          endif
+
           tv1(i)    = t1(i) * (one + rvrdm1*q0(i))
           rho_a(i)  = prsl1(i) / (rd*tv1(i))
           qss(i)    = fpvs(tsurf(i))                          ! pa
@@ -322,11 +326,12 @@ cc
 !           at previous time step
           evap(i)    = elocp * rch(i) * (qss(i) - q0(i))
           qsurf(i)   = qss(i)
-#ifdef GSD_SURFACE_FLUXES_BUGFIX
-          hflx(i)    = rch(i) * (tsurf(i)/prsik1(i) - theta1(i))
-#else
-          hflx(i)    = rch(i) * (tsurf(i) - theta1(i))
-#endif
+
+          if(thsfc_loc) then ! Use local potential temperature
+            hflx(i)    = rch(i) * (tsurf(i) - theta1(i))
+          else ! Use potential temperature referenced to 1000 hPa
+            hflx(i)    = rch(i) * (tsurf(i)/prsik1(i) - theta1(i))
+          endif
 
 !     if (lprnt .and. i == ipr) print *,' tskin=',tskin(i),' theta1=',
 !    & theta1(i),' hflx=',hflx(i),' t1=',t1(i),'prslki=',prslki(i)
@@ -621,11 +626,13 @@ cc
             qss(i)   = eps*qss(i) / (ps(i) + epsm1*qss(i))
             qsurf(i) = qss(i)
             evap(i)  = elocp*rch(i) * (qss(i) - q0(i))
-#ifdef GSD_SURFACE_FLUXES_BUGFIX
-            hflx(i)  = rch(i) * (tskin(i)/prsik1(i) - theta1(i))
-#else
-            hflx(i)  = rch(i) * (tskin(i) - theta1(i))
-#endif
+
+            if(thsfc_loc) then ! Use local potential temperature
+              hflx(i)  = rch(i) * (tskin(i) - theta1(i))
+            else ! Use potential temperature referenced to 1000 hPa
+              hflx(i)  = rch(i) * (tskin(i)/prsik1(i) - theta1(i))
+            endif
+
           endif
         enddo
       endif                   ! if ( nstf_name1 > 1 ) then

--- a/physics/sfc_nst.meta
+++ b/physics/sfc_nst.meta
@@ -410,6 +410,14 @@
   type = integer
   intent = in
   optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [tskin]
   standard_name = surface_skin_temperature_for_nsst
   long_name = ocean surface skin temperature

--- a/physics/sfc_sice.meta
+++ b/physics/sfc_sice.meta
@@ -281,6 +281,14 @@
   type = integer
   intent = in
   optional = F
+[thsfc_loc]
+  standard_name = flag_for_reference_pressure_theta
+  long_name = flag for reference pressure in theta calculation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [hice]
   standard_name = sea_ice_thickness
   long_name = sea-ice thickness


### PR DESCRIPTION
Since the logic that governs GSD_SURFACE_FLUXES_BUGFIX will now come from a namelist variable "thsfc_loc", changes to fv3atm needed to be made.