### PR TITLE
Move sfc emis alb calculation to its own scheme and z0 composite consistent tanya 21apr21

### DIFF
--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -34,7 +34,7 @@ module lsm_ruc
                                flag_restart, flag_init, con_fvirt, con_rd,      &
                                im, lsoil_ruc, lsoil, kice, nlev,                & ! in
                                lsm_ruc, lsm, slmsk, stype, vtype,               & ! in 
-                               t1, q1, prsl1, tsfc_lnd, tsfc_ice, tsfc_wat,     & ! in
+                               q1, prsl1, tsfc_lnd, tsfc_ice, tsfc_wat,         & ! in
                                tg3, smc, slc, stc, fice, min_seaice,            & ! in
                                sncovr_lnd, sncovr_ice, snoalb,                  & ! in
                                facsf, facwf, alvsf, alvwf, alnsf, alnwf,        & ! in
@@ -64,7 +64,6 @@ module lsm_ruc
       real (kind=kind_phys), dimension(im), intent(in) :: slmsk
       real (kind=kind_phys), dimension(im), intent(in) :: stype
       real (kind=kind_phys), dimension(im), intent(in) :: vtype
-      real (kind=kind_phys), dimension(im), intent(in) :: t1
       real (kind=kind_phys), dimension(im), intent(in) :: q1
       real (kind=kind_phys), dimension(im), intent(in) :: prsl1
       real (kind=kind_phys), dimension(im), intent(in) :: tsfc_lnd
@@ -110,7 +109,7 @@ module lsm_ruc
 ! --- local
       real (kind=kind_phys), dimension(lsoil_ruc) :: dzs
       real (kind=kind_phys) :: alb_lnd, alb_ice
-      real (kind=kind_phys) :: q0, qs1, rho
+      real (kind=kind_phys) :: q0, qs1
       integer  :: ipr, i, k
       logical  :: debug_print
       integer, dimension(im) :: soiltyp, vegtype
@@ -185,33 +184,32 @@ module lsm_ruc
         sfalb_lnd_bck(i) = 0.25*(alnsf(i) + alnwf(i) + alvsf(i) + alvwf(i))  &
                            * min(1., facsf(i)+facwf(i))
 
-        !-- land
-        semis_lnd(i) = semisbase(i) * (1.-sncovr_lnd(i))  &
-                     + 0.99 * sncovr_lnd(i)
-        alb_lnd = sfalb_lnd_bck(i) * (1. - sncovr_lnd(i)) &
-                + snoalb(i) * sncovr_lnd(i) 
-        albdvis_lnd(i) = alb_lnd
-        albdnir_lnd(i) = alb_lnd
-        albivis_lnd(i) = alb_lnd
-        albinir_lnd(i) = alb_lnd
-        !-- ice
-        semis_ice(i) = 0.97 * (1. - sncovr_ice(i)) + 0.99 * sncovr_ice(i)
-        alb_ice = 0.55 * (1. - sncovr_ice(i)) + 0.75 * sncovr_ice(i)
-        albdvis_ice(i) = alb_ice 
-        albdnir_ice(i) = alb_ice
-        albivis_ice(i) = alb_ice
-        albinir_ice(i) = alb_ice
-
         if (.not.flag_restart) then
+          !-- land
+          semis_lnd(i) = semisbase(i) * (1.-sncovr_lnd(i))  &
+                       + 0.99 * sncovr_lnd(i)
+          alb_lnd = sfalb_lnd_bck(i) * (1. - sncovr_lnd(i)) &
+                  + snoalb(i) * sncovr_lnd(i) 
+          albdvis_lnd(i) = alb_lnd
+          albdnir_lnd(i) = alb_lnd
+          albivis_lnd(i) = alb_lnd
+          albinir_lnd(i) = alb_lnd
+          !-- ice
+          semis_ice(i) = 0.97 * (1. - sncovr_ice(i)) + 0.99 * sncovr_ice(i)
+          alb_ice = 0.55 * (1. - sncovr_ice(i)) + 0.75 * sncovr_ice(i)
+          albdvis_ice(i) = alb_ice 
+          albdnir_ice(i) = alb_ice
+          albivis_ice(i) = alb_ice
+          albinir_ice(i) = alb_ice
+
           !-- initialize QV mixing ratio at the surface from atm. 1st level
           q0  = max(q1(i)/(1.-q1(i)), 1.e-8)   ! q1=specific humidity at level 1 (kg/kg)
-          rho = prsl1(i) / (con_rd*t1(i)*(1.0+con_fvirt*q0))
           qs1 = rslf(prsl1(i),tsfc_lnd(i))  !* qs1=sat. mixing ratio at level 1 (kg/kg)
           q0  = min(qs1, q0)
           sfcqv_lnd(i) = q0
           qs1 = rslf(prsl1(i),tsfc_ice(i))
           sfcqv_ice(i) = qs1
-        endif
+        endif ! .not. restart
 
       enddo ! i
 

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -164,15 +164,6 @@
   kind = kind_phys
   intent = inout
   optional = F
-[t1]
-  standard_name = air_temperature_at_lowest_model_layer
-  long_name = mean temperature at lowest model layer
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
 [q1]
   standard_name = water_vapor_specific_humidity_at_lowest_model_layer
   long_name = water vapor specific humidity at lowest model layer

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -192,8 +192,8 @@
   intent = inout
   optional = F
 [tsfc_ice]
-  standard_name = surface_skin_temperature_over_ice_interstitial
-  long_name = surface skin temperature over ice   (temporary use as interstitial)
+  standard_name = sea_ice_temperature
+  long_name = sea ice surface skin temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
@@ -1020,6 +1020,33 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
+[min_lakeice]
+  standard_name = lake_ice_minimum
+  long_name = minimum lake ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[min_seaice]
+  standard_name = sea_ice_minimum
+  long_name = minimum sea ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[oceanfrac]
+  standard_name = sea_area_fraction
+  long_name = fraction of horizontal grid area occupied by ocean
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
   optional = F
 [con_cp]
   standard_name = specific_heat_of_dry_air_at_constant_pressure


### PR DESCRIPTION
@climbfuji this PR has several changes in the sfc_drv_ruc.f90/meta for fractional grid. Also, fixed the bug with the use of interstitial array in lsm_ruc_init.