### PR TITLE
correctly convert from flashes per five minutes to flashes per minute

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.F90
@@ -15,6 +15,9 @@ module maximum_hourly_diagnostics
    real(kind=kind_phys), parameter ::PQ0=379.90516E0, A2A=17.2693882, A3=273.16, A4=35.86, RHmin=1.0E-6
    ! *DH
 
+   ! Conversion from flashes per five minutes to flashes per minute.
+   real(kind=kind_phys), parameter :: scaling_factor = 0.2
+
 contains
 
 #if 0
@@ -80,12 +83,6 @@ contains
 !Lightning threat indices
        if (lightning_threat) then
          call lightning_threat_indices
-         ! Lightning threat indices are calculated as flashes per 5 minutes.
-         ! In order to scale that to flashes per minute (standard units),
-         ! we must divide the indices by a factor of 5 / multiply by 0.2
-         ltg1_max = 0.2_kind_phys * ltg1_max
-         ltg2_max = 0.2_kind_phys * ltg2_max
-         ltg3_max = 0.2_kind_phys * ltg3_max
        endif
 
 !Calculate hourly max 1-km agl and -10C reflectivity
@@ -201,7 +198,10 @@ contains
                       endif
                       
                       IF ( ltg1 .LT. clim1 ) ltg1 = 0.
-                      
+
+                      ! Scale to flashes per minue
+                      ltg1 = ltg1 * scaling_factor
+
                       IF ( ltg1 .GT. ltg1_max(i) ) THEN
                          ltg1_max(i) = ltg1
                       ENDIF
@@ -214,14 +214,19 @@ contains
              ltg2 = coef2 * totice_colint(i)
 
              IF ( ltg2 .LT. clim2 ) ltg2 = 0.
+
+             ! Scale to flashes per minute
+             ltg2 = ltg2 * scaling_factor
              
              IF ( ltg2 .GT. ltg2_max(i) ) THEN
                 ltg2_max(i) = ltg2
              ENDIF
 
+             ! This calculation is already in flashes per minute.
              ltg3_max(i) = 0.95 * ltg1_max(i) + 0.05 * ltg2_max(i)
 
-             IF ( ltg3_max(i) .LT. clim3 ) ltg3_max(i) = 0.
+             ! Thus, we must scale clim3. The compiler will optimize this away.
+             IF ( ltg3_max(i) .LT. clim3 * scaling_factor ) ltg3_max(i) = 0.
           enddo
 
        end subroutine lightning_threat_indices

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.meta
@@ -295,7 +295,7 @@
   intent = in
 [ltg1_max]
   standard_name = lightning_threat_index_1
-  long_name = lightning threat index 1 in flashes per 5 minutes
+  long_name = lightning threat index 1
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -303,7 +303,7 @@
   intent = inout
 [ltg2_max]
   standard_name = lightning_threat_index_2
-  long_name = lightning threat index 2 in flashes per 5 minutes
+  long_name = lightning threat index 2
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -311,7 +311,7 @@
   intent = inout
 [ltg3_max]
   standard_name = lightning_threat_index_3
-  long_name = lightning threat index 3 in flashes per 5 minutes
+  long_name = lightning threat index 3
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real


### PR DESCRIPTION
The conversion in the fix_units_flashes_per_5min is incorrect. This does it properly. I've confirmed by running the original version against these changes. Differences are on the order of 1e-6.